### PR TITLE
Improves handling of nested arrays and objects in validation

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Node.js for use with actions
-      uses: actions/setup-node@v1.1.0
+      uses: actions/setup-node@v2
       with:
         version: 10.x
     - name: NPM or Yarn install with caching

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,6 +14,6 @@ jobs:
       with:
         version: 10.x
     - name: NPM or Yarn install with caching
-      uses: bahmutov/npm-install@v1.1.0
+      uses: bahmutov/npm-install@v1.6.2
     - name: Run npm tests
       run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "use-form-state",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-form-state",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "React hook for managing form and input state and form validation.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/createFormValidation.js
+++ b/src/createFormValidation.js
@@ -23,14 +23,14 @@ export function createFieldValidation(
 ) {
     return (path, values, options, parentPath) => {
         if (path.includes('*')) {
-            const pathParts = path.split('.')
+            const pathParts = path.split('.*.')
             const [rootPart] = pathParts
             const rootValue = dotProp.get(values, rootPart)
             return rootValue
                 .map((nestedValues, i) => {
                     const validation = createFieldValidation(validate, message, defaultMessage)
                     return validation(
-                        pathParts[2],
+                        pathParts[1],
                         nestedValues,
                         options,
                         `${rootPart}.${i}`


### PR DESCRIPTION
The validation couldn't handle rules nested in arrays of object like
```
parent {
  array [
    object {
      prop
    }
  ]
}
```
`path: 'parent.array.*.cost'`

Fix:
Splitting on `.*.`  instead of `.` makes sure the correct element is selected to read the prop from 